### PR TITLE
ci: modernize release pipeline (cosign, SBOM, provenance, OCI charts)

### DIFF
--- a/.github/workflows/release-crds.yml
+++ b/.github/workflows/release-crds.yml
@@ -13,28 +13,54 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Package the CRDs chart and publish it as an OCI artifact to GHCR, then
+  # keyless-sign it. version + appVersion are driven from the git tag
+  # (crds-X.Y.Z -> X.Y.Z).
   helm-chart:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write      # push chart to GHCR
+      id-token: write      # cosign keyless / OIDC
+    env:
+      OCI_REPO: oci://ghcr.io/janekbaraniewski/charts
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-
-      - name: Set release version
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/crds-}" >> $GITHUB_ENV
-
-      - name: Use release version in chart
-        run: VERSION=${RELEASE_VERSION} make update-kubeserial-crds-chart-version
-
-      - name: Push chart to charts repository
-        uses: cpina/github-action-push-to-another-repository@v1.7.3
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:
-          source-directory: 'charts/kubeserial-crds'
-          destination-github-username: 'janekbaraniewski'
-          destination-repository-name: 'charts'
-          user-email: dev@baraniewski.com
-          target-branch: main
-          target-directory: 'charts/kubeserial-crds'
+          fetch-depth: 0
+
+      - name: Derive version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/crds-}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5
+        with:
+          version: v3.16.4
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Stamp chart with release version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: CRDS_VERSION="${VERSION}" make update-kubeserial-crds-chart-version
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Package and push chart (OCI)
+        id: push
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          helm package charts/kubeserial-crds --version "${VERSION}" --app-version "${VERSION}"
+          helm push "kubeserial-crds-${VERSION}.tgz" "${OCI_REPO}" 2>&1 | tee push-metadata.txt
+          DIGEST="$(awk '/Digest: /{print $2}' push-metadata.txt)"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Sign chart (keyless, by digest)
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: cosign sign --yes "ghcr.io/janekbaraniewski/charts/kubeserial-crds@${DIGEST}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,112 +12,140 @@ concurrency:
   group: release-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  REGISTRY: ghcr.io
+
 jobs:
-  docker-controller:
+  # Derive the release version from the git tag once, so every downstream job
+  # (images, charts) uses the exact same value. Tags look like "1.2.3".
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Derive version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+  # Build, push, attest (SBOM + SLSA provenance) and keyless-sign each image.
+  # A matrix keeps the three images in one correct-by-construction definition.
+  images:
+    needs: version
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+      packages: write      # push to GHCR
+      id-token: write      # cosign keyless / OIDC
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: kubeserial
+            image: ghcr.io/janekbaraniewski/kubeserial
+            dockerfile: Dockerfile
+          - name: device-monitor
+            image: ghcr.io/janekbaraniewski/kubeserial-device-monitor
+            dockerfile: Dockerfile.monitor
+          - name: injector-webhook
+            image: ghcr.io/janekbaraniewski/kubeserial-injector-webhook
+            dockerfile: Dockerfile.webhook
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to GitHub Container Registry
+      - name: Read target platforms
+        id: platforms
+        run: echo "platforms=$(cat TARGET_PLATFORMS)" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_CONTAINER_REGISTRY_TOKEN }}
-      - name: Set release version
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: Set target platforms
-        run: echo "PLATFORMS=$(cat TARGET_PLATFORMS)" >> $GITHUB_ENV
-      - name: Build
-        run: make kubeserial-docker-all
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-  docker-device-monitor:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v5
+      - name: Extract metadata (tags, OCI labels)
+        id: meta
+        uses: docker/metadata-action@v5
         with:
-          fetch-depth: 0
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+          images: ${{ matrix.image }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.version.outputs.version }}
+            type=raw,value=latest
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GH_CONTAINER_REGISTRY_TOKEN }}
-      - name: Set release version
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: Set target platforms
-        run: echo "PLATFORMS=$(cat TARGET_PLATFORMS)" >> $GITHUB_ENV
-      - name: Build
-        run: make device-monitor-docker-all
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: ${{ steps.platforms.outputs.platforms }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
 
-  docker-injector-webhook:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GH_CONTAINER_REGISTRY_TOKEN }}
-      - name: Set release version
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: Set target platforms
-        run: echo "PLATFORMS=$(cat TARGET_PLATFORMS)" >> $GITHUB_ENV
-      - name: Build
-        run: make injector-webhook-docker-all
-
-  helm-chart:
-    runs-on: ubuntu-latest
-    needs: docker-controller
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Set release version
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-
-      - name: Use release version in chart
-        run: make update-kubeserial-chart-version
-
-      - name: Push chart to charts repository
-        uses: cpina/github-action-push-to-another-repository@v1.7.3
+      - name: Sign image (keyless, by digest)
         env:
-          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE: ${{ matrix.image }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"
+
+  # Package the application chart and publish it as an OCI artifact to GHCR,
+  # then keyless-sign the pushed chart. appVersion + version are driven from
+  # the git tag so chart metadata and image tags always match.
+  helm-chart:
+    needs: [version, images]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write      # push chart to GHCR
+      id-token: write      # cosign keyless / OIDC
+    env:
+      VERSION: ${{ needs.version.outputs.version }}
+      OCI_REPO: oci://ghcr.io/janekbaraniewski/charts
+    steps:
+      - uses: actions/checkout@v5
         with:
-          source-directory: 'charts/kubeserial'
-          destination-github-username: 'janekbaraniewski'
-          destination-repository-name: 'charts'
-          user-email: dev@baraniewski.com
-          target-branch: main
-          target-directory: 'charts/kubeserial'
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5
+        with:
+          version: v3.16.4
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Stamp chart with release version
+        run: APP_VERSION="${VERSION}" make update-kubeserial-chart-version
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Package and push chart (OCI)
+        id: push
+        run: |
+          helm package charts/kubeserial --version "${VERSION}" --app-version "${VERSION}"
+          helm push "kubeserial-${VERSION}.tgz" "${OCI_REPO}" 2>&1 | tee push-metadata.txt
+          DIGEST="$(awk '/Digest: /{print $2}' push-metadata.txt)"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Sign chart (keyless, by digest)
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: cosign sign --yes "ghcr.io/janekbaraniewski/charts/kubeserial@${DIGEST}"


### PR DESCRIPTION
Modernizes the tag-triggered release pipeline. Built by an agent, rebased onto master.

## Images (`release.yml`)
- Single `version` job derives the version once from the git tag, feeding a matrix `images` job (manager / device-monitor / injector-webhook).
- Build+push via `docker/build-push-action@v6` + `docker/metadata-action@v5` (OCI tags/labels), `provenance: mode=max`, `sbom: true`, GHA cache, multi-arch from `TARGET_PLATFORMS`.
- Each image is **cosign keyless-signed** by digest (OIDC).
- Auth switched from the `GH_CONTAINER_REGISTRY_TOKEN` secret to the built-in `GITHUB_TOKEN`; per-job least-privilege `permissions`.

## Charts (`release.yml` + `release-crds.yml`)
- Replaces the cross-repo PAT push (`cpina/...`) with **OCI charts pushed to `ghcr.io/janekbaraniewski/charts`** (both `kubeserial` and `kubeserial-crds`), cosign-signed.

## Issue #81
- Version is derived from the tag and stamped via the existing `make update-*-chart-version` targets, keeping chart version/appVersion and image tags in sync — no hand-editing.

## Consumer-facing changes (breaking for chart install)
```
helm install kubeserial-crds oci://ghcr.io/janekbaraniewski/charts/kubeserial-crds --version X.Y.Z
helm install kubeserial      oci://ghcr.io/janekbaraniewski/charts/kubeserial      --version X.Y.Z
```
The old `helm repo add` flow no longer receives new versions. Image names are unchanged but now ship SBOM + SLSA provenance + cosign signatures (verify with `cosign verify ... --certificate-oidc-issuer https://token.actions.githubusercontent.com`).

## Not verifiable without a real tag push (validated with actionlint + yaml parse only)
- Actual signing / attestation emission / OCI chart push only run on a tag.
- First OCI push will create the `charts` package on GHCR; it may need to be made public + linked to the repo.
- Actions are tag-pinned (not SHA-pinned) — SHA pinning is a possible follow-up.

Closes #81.