### PR TITLE
docs: finish the book (remove WIP placeholders)

### DIFF
--- a/docs/src/components/controllers.md
+++ b/docs/src/components/controllers.md
@@ -1,21 +1,44 @@
-# Controller
+# Controllers
 
-Manages operator components by observing state of each of the devices.
+The controller manager (`cmd/manager`) runs the reconcile loops that drive the rest of the system. It watches the KubeSerial custom resources and creates or removes the Device Monitor, Device Gateways and Manager workloads to match the desired state.
 
 <!-- toc -->
 
-# Controller Loops
+It is configured with a few flags (see `cmd/manager/main.go`):
 
-## KubeSerial Controller
+| Flag | Default | Purpose |
+| --- | --- | --- |
+| `--namespace` | `kubeserial` | Namespace the controllers run in and create resources in |
+| `--device-monitor-version` | `latest` | Tag of the `kubeserial-device-monitor` image to deploy |
+| `--metrics-bind-address` | `:8080` | Metrics endpoint |
+| `--health-probe-bind-address` | `:8081` | Health/readiness probe endpoint |
+| `--leader-elect` | `false` | Enable leader election |
 
-## SerialDevice Controller
-
-## ManagerScheduleRequest Controller
+## Controller Loops
 
 ```mermaid
 graph TD;
-    A-->B;
-    A-->C;
-    B-->D;
-    C-->D;
+    KS[KubeSerial] -->|KubeSerial Controller| DM[Device Monitor<br/>ConfigMap + DaemonSet];
+    SD[SerialDevice] -->|SerialDevice Controller| DG[Device Gateway<br/>CM + Deployment + Service];
+    SD -->|SerialDevice Controller| MSR[ManagerScheduleRequest];
+    MSR -->|ManagerScheduleRequest Controller| MGR[Manager workload<br/>CM + Deployment + Service];
 ```
+
+### KubeSerial Controller
+
+Reconciles the [`KubeSerial`](../configuration/kubeserial.md) resource. From its `spec.serialDevices` list it builds the udev rules ConfigMap and the Device Monitor DaemonSet, then ensures both exist in the cluster. This is what turns your device list into a running monitor on every node.
+
+### SerialDevice Controller
+
+Reconciles each [`SerialDevice`](../configuration/devices.md). On every reconcile it:
+
+1. ensures the `Available`, `Ready` and `Free` conditions exist (creating them as `False`/`NotValidated` if missing);
+2. validates the device is ready - if the device references a manager, the referenced [`Manager`](../configuration/managers/internal.md) object must exist, otherwise `Ready` is set to `False` with reason `ManagerNotAvailable`;
+3. if the device is `Available` (the monitor has detected it), it requests a [Device Gateway](gateway.md) and, when the device declares a manager, creates a `ManagerScheduleRequest`;
+4. if the device is not `Available`, it tears the gateway down again and removes any `ManagerScheduleRequest`.
+
+The gateway and the schedule request are owned by the SerialDevice, so they are garbage collected automatically.
+
+### ManagerScheduleRequest Controller
+
+Reconciles each `ManagerScheduleRequest` (created by the SerialDevice controller). It looks up the referenced `Manager`, then schedules the management workload for the device: a Deployment running the manager image, a Service, and a ConfigMap when the manager provides config. The deployment's command is wrapped with `socat` so the manager container sees the device as a local `/dev/device` bridged to the gateway. See [Manager scheduled by KubeSerial](../configuration/managers/internal.md).

--- a/docs/src/components/gateway.md
+++ b/docs/src/components/gateway.md
@@ -1,3 +1,23 @@
-# SerialDevice Gateway
-Exposed specific device in cluster network over TCP.
+# Device Gateway
+
+Exposes a specific device on the cluster network over TCP.
+
 <!-- toc -->
+
+## How it works
+
+When a [`SerialDevice`](../configuration/devices.md) becomes `Available`, the [SerialDevice controller](controllers.md) creates a Device Gateway for it. A gateway is three resources, all named `<device>-gateway`:
+
+- a **ConfigMap** holding a `ser2net.conf`,
+- a **Deployment** running `ser2net`,
+- a **`ClusterIP` Service** publishing port `3333`.
+
+The `ser2net` container is privileged and mounts the host `/dev`. Its config maps the device to a raw TCP port:
+
+```
+3333:raw:600:/dev/ender3:115200 8DATABITS NONE 1STOPBIT -XONXOFF LOCAL -RTSCTS HANGUP_WHEN_DONE
+```
+
+The deployment is pinned to the node the device is attached to using a `kubernetes.io/hostname` node selector set from the device's `status.nodeName` (written by the [Device Monitor](monitor.md)). This is why the device only needs to be physically present on one node: the gateway always lands on that node, and everything else reaches it through the service.
+
+Consumers connect to `<device>-gateway:3333` and turn that TCP stream back into a local serial port with `socat` (see the [Manager](manager.md) and the [device-injection webhook](../configuration/managers/external.md)). When the device is unplugged, the controller deletes the ConfigMap, Deployment and Service again.

--- a/docs/src/components/manager.md
+++ b/docs/src/components/manager.md
@@ -1,5 +1,27 @@
 # Manager
 
-Creates deployment with management software, mounts your device over the network and gives you access through ingress rule.
+A Manager is the management software that talks to a device (for example OctoPrint for a 3D printer, or Zigbee2MQTT for a Zigbee dongle). KubeSerial can schedule a Manager for you automatically whenever its device is connected, and tear it down again when the device goes away.
 
 <!-- toc -->
+
+## How it works
+
+You declare a [`Manager`](../configuration/managers/internal.md) resource describing the image, the run command and optional config, and reference it from a `SerialDevice` (`spec.manager`). When that device becomes available the [controllers](controllers.md) create a `ManagerScheduleRequest`, and the ManagerScheduleRequest controller schedules the workload:
+
+- a **Deployment** running the manager image,
+- a **`ClusterIP` Service** on port `80`,
+- a **ConfigMap** with the rendered config, mounted at the manager's `configPath` (only when `spec.config` is set).
+
+The deployment's entrypoint is wrapped so that, before the manager starts, a `socat` bridge connects the [Device Gateway](gateway.md) to a local PTY:
+
+```sh
+socat -d -d pty,raw,echo=0,b115200,link=/dev/device,perm=0660,group=tty tcp:<device>-gateway:3333 & <runCmd>
+```
+
+The manager then talks to `/dev/device` as if the hardware were attached locally, while the bytes actually travel over the network to the node holding the device.
+
+> Ingress for managers is not wired up in the current release; reach managers through their Service.
+
+## Two ways to attach a device
+
+Running a predefined Manager is one of two supported modes. The other is the [device-injection webhook](../configuration/managers/external.md), which applies the same `socat` bridge to *any* pod via an annotation, without you defining a Manager resource. See the [Managers](../configuration/managers/SUMMARY.md) overview for when to use each.

--- a/docs/src/components/monitor.md
+++ b/docs/src/components/monitor.md
@@ -1,7 +1,25 @@
-# SerialDeviceMonitor
+# Device Monitor
 
-Monitors cluster nodes waiting for specified serial devices to be connected and updates their state.
+Monitors cluster nodes waiting for the configured serial devices to be connected and keeps each [`SerialDevice`](../configuration/devices.md) status in sync with what is actually plugged in.
 
 <!-- toc -->
 
 ## How it works
+
+The Device Monitor is deployed by the [KubeSerial controller](controllers.md) as a `DaemonSet`, so one instance runs on every node. Each pod has two containers:
+
+- **`udev-monitor`** mounts the host `/dev` and a generated udev rules file (`98-devices.rules`). For each device in the [KubeSerial](../configuration/kubeserial.md) spec it gets a rule of the form:
+
+  ```
+  SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", SYMLINK+="ender3"
+  ```
+
+  This makes udev create a stable `/dev/<device-name>` symlink whenever the matching USB device is connected, regardless of the kernel-assigned `ttyUSB*` name.
+
+- **`device-monitor`** runs the reconcile loop. Once per second it lists all `SerialDevice` resources whose `Ready` condition is `True` and, for each, `stat`s `/dev/<device-name>` on its node:
+  - if the device file exists and the device is not yet marked available, it sets `Available=True` and `Free=True` and records its own node name in `status.nodeName`;
+  - if the device disappears from the node that owned it, it sets `Available=False`, `Free=Unknown` and clears `status.nodeName`.
+
+Because the monitor writes `status.nodeName`, the rest of the system always knows which node a device is attached to. That is what lets the controller pin the [Device Gateway](gateway.md) to the correct node.
+
+Both containers run privileged and mount the host `/dev` so they can see the physical devices. The `device-monitor` container reads its namespace and node name from the `OPERATOR_NAMESPACE` and `NODE_NAME` environment variables.

--- a/docs/src/configuration/SUMMARY.md
+++ b/docs/src/configuration/SUMMARY.md
@@ -1,1 +1,7 @@
 # Configuration
+
+KubeSerial is configured through a handful of cluster-scoped custom resources. In a typical Helm install you describe everything in one [`KubeSerial`](kubeserial.md) resource and the controllers derive the rest, but you can also manage the individual objects directly.
+
+- [KubeSerial](kubeserial.md) - the top-level resource listing every device you want to expose.
+- [Devices](devices.md) - the `SerialDevice` objects that represent a single device and carry its status.
+- [Managers](managers/SUMMARY.md) - how to attach management software or arbitrary workloads to a device.

--- a/docs/src/configuration/devices.md
+++ b/docs/src/configuration/devices.md
@@ -1,5 +1,7 @@
 # Device
 
+A `SerialDevice` represents one physical device. You normally don't create these by hand: the [KubeSerial controller](../components/controllers.md) generates one per entry in the [KubeSerial](kubeserial.md) `serialDevices` list. The [Device Monitor](../components/monitor.md) and the controllers keep its `status` in sync with reality.
+
 <!-- toc -->
 
 ## Spec
@@ -8,42 +10,58 @@
 apiVersion: app.kubeserial.com/v1alpha1
 kind: SerialDevice
 metadata:
-  annotations:
-    ...
-  labels:
-    ...
   name: ender3
 spec:
-  idProduct: "6001"
-  idVendor: "0403"
-  manager: octoprint
   name: ender3
+  idVendor: "0403"
+  idProduct: "6001"
+  manager: octoprint
 ```
 
+| Field | Required | Description |
+| --- | --- | --- |
+| `name` | yes | Device name. Matches the `/dev/<name>` symlink created by the udev rule. |
+| `idVendor` | yes | USB vendor id. |
+| `idProduct` | yes | USB product id. |
+| `manager` | no | Name of a [`Manager`](managers/internal.md) to schedule when the device is available. |
+
+`SerialDevice` is cluster-scoped. `kubectl get serialdevice` prints the `Ready`, `Available` and `Node` columns.
+
 ## Status conditions
+
+The status carries three conditions and, once the device is detected, the node it is attached to:
+
+| Condition | Set by | Meaning |
+| --- | --- | --- |
+| `Ready` | SerialDevice controller | Configuration has been validated. If the device references a manager, that `Manager` object must exist; otherwise the device is ready immediately. |
+| `Available` | Device Monitor | The device file is currently present on a node. `status.nodeName` records which one. |
+| `Free` | Device Monitor / webhook | The device is available and not in use. The [injection webhook](managers/external.md) only injects into a pod when `Free` is `True`. |
 
 ```yaml
 apiVersion: app.kubeserial.com/v1alpha1
 kind: SerialDevice
 ...
 status:
+  nodeName: worker-1
   conditions:
-  - lastHeartbeatTime: "2022-06-05T23:49:02Z"
-    lastTransitionTime: "2022-06-05T23:49:02Z"
-    message: ""
-    reason: NotValidated
-    status: "False"
-    type: Available
-  - lastHeartbeatTime: "2022-06-05T23:49:02Z"
-    lastTransitionTime: "2022-06-05T23:49:02Z"
-    message: ""
-    reason: AllChecksPassed
+  - type: Ready
     status: "True"
-    type: Ready
-  - lastHeartbeatTime: "2022-06-05T23:49:02Z"
+    reason: AllChecksPassed
+    lastHeartbeatTime: "2022-06-05T23:49:02Z"
     lastTransitionTime: "2022-06-05T23:49:02Z"
     message: ""
-    reason: NotValidated
-    status: "False"
-    type: Free
+  - type: Available
+    status: "True"
+    reason: DeviceAvailable
+    lastHeartbeatTime: "2022-06-05T23:49:02Z"
+    lastTransitionTime: "2022-06-05T23:49:02Z"
+    message: ""
+  - type: Free
+    status: "True"
+    reason: DeviceFree
+    lastHeartbeatTime: "2022-06-05T23:49:02Z"
+    lastTransitionTime: "2022-06-05T23:49:02Z"
+    message: ""
 ```
+
+When the device is unplugged the monitor sets `Available` to `False`, `Free` to `Unknown` and clears `status.nodeName`, and the controller removes the [gateway](../components/gateway.md) and any manager scheduled for it.

--- a/docs/src/configuration/kubeserial.md
+++ b/docs/src/configuration/kubeserial.md
@@ -1,13 +1,11 @@
 # KubeSerial
 
+The `KubeSerial` resource is the single place where you declare which devices the cluster should expose. The Helm chart creates one for you from the `kubeserial.serialDevices` values, and the [KubeSerial controller](../components/controllers.md) turns its `serialDevices` list into the [Device Monitor](../components/monitor.md) and the per-device [`SerialDevice`](devices.md) objects.
+
 ```yaml
 apiVersion: app.kubeserial.com/v1alpha1
 kind: KubeSerial
 metadata:
-  annotations:
-    ...
-  labels:
-    ...
   name: kubeserial
   namespace: kubeserial
 spec:
@@ -22,3 +20,18 @@ spec:
     idVendor: 10c4
     name: sonoff-zigbee
 ```
+
+## Spec
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `serialDevices` | yes | List of devices to expose. |
+| `serialDevices[].name` | yes | Device name. Becomes the `/dev/<name>` udev symlink and the prefix for the generated gateway/manager resources. |
+| `serialDevices[].idVendor` | yes | USB vendor id used to match the device. |
+| `serialDevices[].idProduct` | yes | USB product id used to match the device. |
+| `serialDevices[].manager` | no | Name of a [`Manager`](managers/internal.md) to schedule automatically when this device is connected. Omit it to drive the device with the [injection webhook](managers/external.md) instead. |
+| `ingress.enabled` | yes | Reserved for manager ingress. Ingress is not wired up in the current release, leave it `false`. |
+| `ingress.domain` | no | Domain used when ingress is enabled. |
+| `ingress.annotations` | no | Annotations added to generated ingress objects. |
+
+> Quote `idVendor` / `idProduct` values that are all digits (for example `"6001"`) so they are treated as strings.

--- a/docs/src/configuration/managers/SUMMARY.md
+++ b/docs/src/configuration/managers/SUMMARY.md
@@ -1,19 +1,18 @@
 # Managers
 
-> In order to learn more about concept of Manager take a look at [Manager docs][MD]
+> To learn more about the concept of a Manager take a look at the [Manager docs][MD].
 
-Manager configuration is not required, although it's the easiest way to work with serial devices using KubeSerial.
-
-There are 2 ways to work with managers. You can use them both at the same time for different devices, but not for the same one.
+Configuring a manager is not required, but it is the easiest way to actually use a device once KubeSerial has exposed it. There are two ways to attach something to a device. You can use both at the same time for different devices, but not for the same device.
 
 ## Manager scheduled by KubeSerial
 
-In this approach, you'll need to create `Manager` type object which will hold spec of manager software you want to run and bind it with `SerialDevice`. Then, when KubeSerial detects that device is connected, it will schedule management software for you and create link to the device inside. Once device is disconnected, everything is cleaned up. Learn how to configure it by [reading the docs][MIC]
-## Manager scheduled externaly
+You create a `Manager` resource holding the spec of the management software you want to run and bind it to a `SerialDevice` (via `spec.manager`). When KubeSerial detects that the device is connected it schedules the management software for you and bridges the device into the container. When the device is disconnected everything is cleaned up. Learn how to configure it by [reading the docs][MIC].
 
-In this approach, you add annotation to your Pod and KubeSerial mutating webhook will update pod spec when it's created to inject connection to device. Learn how to configure it by [reading the docs][MEC]
+## Manager scheduled externally
+
+You add an annotation to your Pod and the KubeSerial mutating webhook rewrites the pod when it is created to bridge in the device. This works with any image and needs no `Manager` resource. Learn how to configure it by [reading the docs][MEC].
 
 <!-- Links  -->
-[MD]:  /components/manager.md            "Manager"
-[MIC]: /configuration/managers/internal.md "Manager internal"
-[MEC]: /configuration/managers/external.md "Manager external"
+[MD]:  ../../components/manager.md   "Manager"
+[MIC]: internal.md                  "Manager internal"
+[MEC]: external.md                  "Manager external"

--- a/docs/src/configuration/managers/external.md
+++ b/docs/src/configuration/managers/external.md
@@ -1,1 +1,49 @@
-# Manager scheduled externaly
+# Manager scheduled externally
+
+Instead of defining a `Manager` resource, you can attach a device to any pod you already run by adding a single annotation. The KubeSerial mutating webhook rewrites the pod at creation time so its container reaches the device over the network. This lets you use a device from an off-the-shelf image without rebuilding it or running a privileged pod yourself.
+
+<!-- toc -->
+
+## Usage
+
+Add the annotation to the pod template, naming the [`SerialDevice`](../devices.md) you want:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zigbee2mqtt
+spec:
+  template:
+    metadata:
+      annotations:
+        app.kubeserial.com/inject-device: sonoff-zigbee
+    spec:
+      containers:
+      - name: zigbee2mqtt
+        image: koenkk/zigbee2mqtt:latest
+```
+
+The device name must match a `SerialDevice` (`sonoff-zigbee` in the [Quick Start](../../quick_start.md) example). Inside the container the device is available as `/dev/device`, so point your software at that path.
+
+## How it works
+
+The webhook is a `MutatingWebhookConfiguration` that intercepts pod `create` and `update` calls. For each pod it:
+
+1. Reads the `app.kubeserial.com/inject-device` annotation. If it is missing, the pod is left untouched.
+2. Looks up the named `SerialDevice` and checks that its `Free` condition is `True`. If the device does not exist or is not free, the pod is admitted unchanged (no bridge is injected).
+3. Rewrites the first container's `command`/`args` to start a `socat` bridge before the original process:
+
+   ```sh
+   socat -d -d pty,raw,echo=0,b115200,link=/dev/device,perm=0660,group=tty tcp:sonoff-zigbee-gateway:3333 & <original entrypoint>
+   ```
+
+   `socat` creates a local PTY at `/dev/device` and connects it to the device's [gateway](../../components/gateway.md) service. The original entrypoint then runs as usual and talks to `/dev/device`.
+
+If the container does not set an explicit `command`, the webhook reads the image's OCI config to recover the image's entrypoint and command, so it can wrap them correctly. It also sets an `app.kubeserial.com/device-injected` annotation so the same pod is not rewritten twice.
+
+## Requirements and limitations
+
+- The device's gateway must be running, which means the `SerialDevice` has to be `Available` and `Free`. If it is not free at the moment the pod is created, the pod starts without the bridge.
+- Only the first container in the pod is rewritten.
+- The webhook needs its serving certificate; cert-manager and a configured issuer are part of the [install requirements](../../quick_start.md).

--- a/docs/src/configuration/managers/internal.md
+++ b/docs/src/configuration/managers/internal.md
@@ -1,69 +1,48 @@
 # Manager scheduled by KubeSerial
 
+A `Manager` describes a piece of management software to run for a device. Reference it from a `SerialDevice` (`spec.manager`) and KubeSerial schedules it automatically while the device is connected. See the [Manager component docs](../../components/manager.md) for how the workload is built and bridged to the device.
+
+<!-- toc -->
+
+## Spec
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `image.repository` | yes | Manager image repository. |
+| `image.tag` | yes | Manager image tag. |
+| `runCmd` | yes | Command used to start the software. It is run after the `socat` bridge is established, so the device is already present at `/dev/device`. |
+| `config` | no | Inline configuration file content. When set, it is written to a ConfigMap and mounted at `configPath`. |
+| `configPath` | no | Path inside the container where `config` is mounted (for example `/data/config.yaml`). |
+
+`Manager` is cluster-scoped.
+
+## Example
+
+This is an OctoPrint manager for the `ender3` printer used in the [Quick Start](../../quick_start.md):
+
 ```yaml
 apiVersion: app.kubeserial.com/v1alpha1
 kind: Manager
 metadata:
-  annotations:
-    meta.helm.sh/release-name: kubeserial
-    meta.helm.sh/release-namespace: kubeserial
-  creationTimestamp: "2022-06-05T23:48:43Z"
-  generation: 1
-  labels:
-    app.kubernetes.io/instance: kubeserial
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: kubeserial
-    app.kubernetes.io/version: 0.0.1-8c68648
-    helm.sh/chart: kubeserial-0.0.1-8c68648
   name: octoprint
-  resourceVersion: "43158"
-  uid: c908bad7-8716-4f50-aa3f-aeb91bebe71f
+  namespace: kubeserial
 spec:
+  image:
+    repository: janekbaraniewski/octoprint
+    tag: 1.3.10
+  configPath: /data/config.yaml
   config: |
     accessControl:
       enabled: false
-    plugins:
-      announcements:
-        _config_version: 1
-        channels:
-          _blog:
-            read_until: 1573642500
-          _important:
-            read_until: 1521111600
-          _octopi:
-            read_until: 1573722900
-          _plugins:
-            read_until: 1573862400
-          _releases:
-            read_until: 1574699400
-      discovery:
-        upnpUuid: ef35acc7-a859-4947-980d-d5edb10508e4
-      softwareupdate:
-        _config_version: 6
-      tracking:
-        enabled: false
-    deviceProfiles:
-      default: _default
     serial:
       additionalPorts:
-      - /dev/devices/ender3
+      - /dev/device
       autoconnect: true
       baudrate: 0
       port: /dev/device
     server:
       firstRun: false
-      onlineCheck:
-        enabled: true
-      pluginBlacklist:
-        enabled: false
-      seenWizards:
-        corewizard: 3
-        cura: null
-        tracking: null`
-  configPath: /data/config.yaml
-  image:
-    repository: janekbaraniewski/octoprint
-    tag: 1.3.10
-  runCmd: mkdir /root/.octoprint && cp /data/config.yaml /root/.octoprint/config.yaml
-    && /OctoPrint-1.3.10/run --iknowwhatimdoing --port 80
+  runCmd: mkdir /root/.octoprint && cp /data/config.yaml /root/.octoprint/config.yaml && /OctoPrint-1.3.10/run --iknowwhatimdoing --port 80
 ```
+
+The device shows up inside the manager container as `/dev/device`, so the manager's own configuration should point at that path.

--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -4,7 +4,7 @@
 
 ## Intro
 
-Most things you'd need for local development are covered in Makefile. Just run `make help` to see available commands:
+Most things you'd need for local development are covered in the Makefile. Just run `make help` to see available commands:
 
 ```zsh
 ➜  make help
@@ -16,15 +16,20 @@ General
   help             Display this help.
 
 Development
+  generate         Generate files
+  check-generated  Check that generated files are up to date
   fmt              Run go fmt against code.
   vet              Run go vet against code.
   test             Run tests.
-  test-fswatch     Use fswatch to watch source files and run tests on chamnge
+  test-fswatch     Use fswatch to watch source files and run tests on change
+  lint             Run golangci-lint
+  check            Run linters and check code gen
 
 Run
   run              Run codegen and start controller from your host.
 
 Docker
+  docker-local                   Build images for local dev
   kubeserial-docker-local        Build image for local development, tag local, supports only builder platform
   kubeserial-docker-all          Build and push image for all target platforms
   device-monitor-docker-local    Build image for local development, tag local, supports only builder platform
@@ -36,29 +41,37 @@ Helm
   update-kubeserial-chart-version       Update version used in chart. Requires VERSION var to be set
   update-kubeserial-crds-chart-version  Update version used in chart. Requires VERSION var to be set
   helm-lint                             Run chart-testing to lint kubeserial chart.
+  update-version                        Update charts version.
 
 Kind
+  kind                  Create kind cluster, install certmanager, build and load images, install dev release.
+  install-certmanager   Install cert-manager from jetstack/cert-manager
 
 Minikube
   minikube              Start local cluster, build image and deploy
   minikube-start        Start minikube cluster
   minikube-set-context  Set context to use minikube cluster
-  minikube-deploy       Deploy the app to local minikube
 
 Deployment
   uninstall        Uninstall release.
   deploy-dev       Install dev release in current context/namespace.
+  install-dev      Install dev release in current context/namespace.
 
 Docs
   docs-deps        Install mdbook (requires rust and cargo) + plugins
   docs-serve       Build docs, start server and open in browser
-
-Build
-  kubeserial        Build manager binary.
-  device-monitor    Build device monitor binary
-  injector-webhook  Build sidecar injector webhook binary binary
-  all               Run codegen and build all components.
 ```
+
+## Code generation
+
+KubeSerial uses two kinds of generated files: the typed client / deepcopy / openapi code under `pkg/generated` and `pkg/apis`, and the CRD manifests rendered into `charts/kubeserial-crds`. Both are produced by scripts in `hack/`:
+
+```bash
+$ make generate          # regenerate client code (code-gen) and CRD manifests (manifests-gen)
+$ make check-generated   # verify the committed output is up to date (used in CI)
+```
+
+`make run` and `make test` run `generate` for you, so after editing types under `pkg/apis/v1alpha1` you normally don't need to invoke it by hand.
 
 ## Running tests
 
@@ -68,7 +81,7 @@ After any change run
 $ make test
 ```
 
-to run tests suite
+to run the test suite. This formats and vets the code, downloads `setup-envtest`, renders the CRDs and starts an `envtest` control plane (the `ENVTEST_K8S_VERSION` set in the Makefile) so the controller integration tests under `pkg/controllers/integration_tests` can run against a real API server. Coverage is written to `coverage.txt`.
 
 You can also find it helpful to just run tests every time there is a change in project source files, for this run
 
@@ -76,37 +89,78 @@ You can also find it helpful to just run tests every time there is a change in p
 $ make test-fswatch
 ```
 
-which will run `test` target every time it detects change using `fswatch` (`fswatch` must be installed)
+which will run the `test` target every time it detects a change using `fswatch` (`fswatch` must be installed).
+
+## Linting
+
+```bash
+$ make lint    # golangci-lint
+$ make check   # check-generated + lint, the combined CI gate
+```
 
 ## Building images
 
-There are sets of 2 targets for each image that is a part of this project:
+There are sets of 2 targets for each of the three images in this project (`kubeserial`, `device-monitor`, `injector-webhook`):
 
 > *-docker-local
 
-which builds docker image for local development
-
-and 
+which builds the docker image for local development, and
 
 > *-docker-all
 
-which builds docker image for all target architectures.
+which builds and pushes the image for all target architectures (the platforms listed in the `TARGET_PLATFORMS` file).
 
-For local development you'll only need to build local images
+For local development you'll only need to build local images.
 
-### Building images localy
+### Building images locally
 
-<mark>Docker buildx builder with support for platforms listed in TARGET_PLATFORMS is required</mark>
+<mark>A Docker buildx builder with support for the platforms listed in TARGET_PLATFORMS is required</mark>
 
-If you want to build all images using your local Docker, run
+To build all three images at once using your local Docker, run
 
 ```zsh
-$ make docker-local 
+$ make docker-local
 ```
 
-This will execute all `*-docker-local` targets and build images using your local Docker.
+This runs every `*-docker-local` target and loads the images into your local Docker.
 
-## Running minikube
+## Running on a local cluster
 
-TODO
-<!-- TODO -->
+There are two ready-made flows for spinning up a full local environment: kind and minikube. Both build the images, install cert-manager (the webhook needs it for its serving certificate) and deploy a dev release of the CRDs and the controllers.
+
+### kind
+
+```bash
+$ make kind
+```
+
+This creates a kind cluster named `kubeserial`, installs cert-manager, builds the local images, loads them into the cluster and installs the dev release.
+
+### minikube
+
+```bash
+$ make minikube
+```
+
+This starts a minikube profile named `kubeserial`, builds the controller and monitor images directly into minikube's Docker daemon, installs cert-manager and deploys the dev release.
+
+Use `make minikube-set-context` to point your kubectl context at the minikube cluster.
+
+### Deploying into an existing cluster
+
+If you already have a cluster and just want to (re)install the dev release into it:
+
+```bash
+$ make install-dev
+```
+
+This bumps the chart versions and installs both the `kubeserial-crds` and `kubeserial` charts into the `kubeserial` namespace, using `charts/kubeserial/values-local.yaml`. Run `make uninstall` to remove the release.
+
+## Working on the docs
+
+The docs are built with [mdBook](https://rust-lang.github.io/mdBook/) and use the `mermaid`, `toc` and `open-on-gh` preprocessors.
+
+```bash
+$ make docs-deps    # install mdbook and the required plugins (needs rust + cargo)
+$ make docs-serve   # build, serve and open the book in your browser
+```

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -1,24 +1,45 @@
-# KubeSerial 
-
-<mark>THIS IS STILL WORK IN PROGRESS</mark>
+# KubeSerial
 
 <b>Work with serial devices in Kubernetes</b>
 
 ---
 
-<mark>THIS IS STILL WORK IN PROGRESS</mark>
-
-KubeSerial is a set of Kubernetes controllers and resources that make working with serial devices in Kubernetes clusters easy. It decouples node that device is connected to from workload that's using it.
+KubeSerial is a set of Kubernetes controllers and a mutating webhook that make physical serial devices (3D printers, Zigbee/Z-Wave dongles, microcontrollers, anything that shows up under `/dev`) usable from any workload in your cluster. It decouples the node a device is physically plugged into from the workload that wants to talk to it: a pod scheduled anywhere in the cluster reaches the device over the network as if it were local.
 
 ## How it works
 
-KubeSerial uses [Device Monitors][DM] to monitor all cluster nodes for [Devices][D]. Once [Device][D] is detected, it will schedule [Device Gateway][DG] to specific cluster node. [Device Gateway][DG] exposes this device as TCP server. Once [Device Gateway][DG] is available, it can be used by [Manager][M]. There are 2 supported modes for [Managers][M]:
-- Use predefined Manager that will be scheduled when Device is available
-- Use annotation to inject device to any workload
+You describe your devices once (by USB `idVendor` / `idProduct`) in a [KubeSerial][KS] resource. From there KubeSerial takes care of detection, exposure and consumption:
 
+```mermaid
+graph TD;
+    KS[KubeSerial CR] -->|configures| DM[Device Monitor DaemonSet];
+    DM -->|device plugged in,<br/>flips SerialDevice conditions| SD[SerialDevice];
+    SD -->|Available| DG[Device Gateway<br/>ser2net on device's node];
+    SD -->|has manager| M[Manager workload];
+    DG -.->|TCP :3333| M;
+    DG -.->|TCP :3333| W[Pod with inject-device<br/>annotation];
+```
+
+1. The [Device Monitor][DM] runs as a DaemonSet on every node. It writes udev rules derived from your device list, then watches `/dev` for the matching symlinks. When a device appears or disappears it flips the conditions on the corresponding [SerialDevice][D] and records which node it is attached to.
+2. Once a [SerialDevice][D] becomes `Available`, the controllers schedule a [Device Gateway][DG] onto that exact node. The gateway runs `ser2net` and exposes the device over TCP as a `ClusterIP` service (`<device>-gateway:3333`).
+3. With the gateway in place the device can be consumed in one of two ways:
+   - **A predefined [Manager][M]** scheduled automatically when the device connects (for example an OctoPrint instance for a 3D printer).
+   - **The device-injection webhook**, which lets you attach the device to *any* pod by adding a single annotation, with no image changes. See [Manager scheduled externally][MEC].
+
+In both cases the consuming container gets a local `/dev/device` PTY (created by `socat`) that is bridged to the gateway, so existing software keeps talking to a plain serial port.
+
+## When to use it
+
+KubeSerial is a good fit when:
+
+- you have serial/USB devices attached to specific nodes but want to run the software that uses them anywhere in the cluster;
+- you want devices to be discovered and exposed automatically as they are plugged in and unplugged;
+- you want to give an arbitrary workload access to a device without rebuilding its image.
 
 <!-- Links  -->
-[D]:  /configuration/devices.md            "Device"
-[DM]: /components/monitor.md               "Device Monitor"
-[DG]: /components/gateway.md               "Device Gateway"
-[M]:  /configuration/managers/SUMMARY.md   "Managers"
+[KS]: configuration/kubeserial.md          "KubeSerial"
+[D]:  configuration/devices.md             "Device"
+[DM]: components/monitor.md                "Device Monitor"
+[DG]: components/gateway.md                "Device Gateway"
+[M]:  configuration/managers/SUMMARY.md    "Managers"
+[MEC]: configuration/managers/external.md  "Manager external"

--- a/docs/src/quick_start.md
+++ b/docs/src/quick_start.md
@@ -4,14 +4,14 @@
 
 ## Requirements
 
-- k8s cluster
-- CertManager installed and Cert Issuer configured
+- a Kubernetes cluster
+- [cert-manager](https://cert-manager.io/) installed, with an Issuer or ClusterIssuer configured (the device-injection webhook needs it for its serving certificate)
 
 ## Install with Helm
 
-### Add help repo
+### Add the Helm repo
 
-First you'll need to add helm repository that stores KubeSerial charts
+First add the Helm repository that hosts the KubeSerial charts:
 
 ```bash
 > helm repo add baraniewski https://baraniewski.com/charts/
@@ -19,15 +19,15 @@ First you'll need to add helm repository that stores KubeSerial charts
 
 ### Install CRDs
 
-Due to way in which helm handles CRDs, they are managed using separate chart.
+Because of the way Helm handles CRDs, they are shipped as a separate chart:
 
 ```bash
 > helm upgrade --install kubeserial-crds baraniewski/kubeserial-crds
 ```
 
-### Create minimal values file
+### Create a minimal values file
 
-In order to make webhook work, you'll need to specify which Cert Issuer should be used for SSL cert used by webhook. To do this, create values file with following structure (change values depending on your setup):
+For the webhook to work you must tell it which issuer to use for its TLS certificate. Create a values file like this (adjust to your setup):
 
 ```yaml
 certManagerIssuer:
@@ -35,29 +35,29 @@ certManagerIssuer:
   kind: ClusterIssuer
 ```
 
-<mark>Set proper name and kind of your Issuer or ClusterIssuer</mark>
+<mark>Set the proper name and kind of your Issuer or ClusterIssuer</mark>
 
-### Install Controller
+### Install the controllers
 
 ```bash
-> helm upgrade --install kubeserial baraniewski/kubeserial
+> helm upgrade --install kubeserial baraniewski/kubeserial -f my-values.yaml
 ```
 
 ## Get device attributes
 
-To find out values of `idVendor` and `idProduct` for your device, connect it to your computer, locate where it is (let's say `/dev/ttyUSB0`) and run:
+To find the `idVendor` and `idProduct` for your device, connect it to a machine, find its node (say `/dev/ttyUSB0`) and run:
 
 ```bash
 > udevadm info -q all -n /dev/ttyUSB0 --attribute-walk
 ```
 
-Look for them from the top.
+Look for them near the top of the output.
 
-## Update helm values file
+## Add your devices
 
-Now you're ready to create configuration for your devices. Here you can find example of 2 devices - one is using predefined manager, one doesn't. To learn about the difference, please refer to [manager configuration docs](configuration/managers/SUMMARY.md)
+Now declare your devices. The example below has two: one is bound to a predefined manager, one is not. To learn about the difference, see the [manager configuration docs](configuration/managers/SUMMARY.md).
 
-Add this config to your values file:
+Add this to your values file:
 
 ```yaml
 kubeserial:
@@ -71,7 +71,9 @@ kubeserial:
     name: sonoff-zigbee
 ```
 
-## Update your helm release with new values
+> Quote values that are all digits (for example `"6001"`) so they stay strings.
+
+## Update your release with the new values
 
 ```bash
 > helm upgrade kubeserial baraniewski/kubeserial -f my-values.yaml
@@ -79,25 +81,27 @@ kubeserial:
 
 ## Validate that everything is working
 
-You should see 3 workloads in your cluster - controler manager, device injector webhook and device monitor:
+You should see three workloads in your cluster - the controller manager, the device-injection webhook and the device monitor:
 
 ```bash
-$ ➜  kubectl get pods
+$ kubectl get pods
 NAME                                         READY   STATUS    RESTARTS   AGE
 kubeserial-7d58555d4c-97nqk                  1/1     Running   0          5m
 kubeserial-device-injector-cc7696b59-mfdn5   1/1     Running   0          5m
 kubeserial-monitor-rjs82                     2/2     Running   0          5m
 ```
 
-Number of `kubeserial-monitor` pods should match number of your cluster nodes.
+The number of `kubeserial-monitor` pods should match the number of nodes in your cluster.
 
 You should also see your devices:
 
 ```bash
-$ ➜  kubectl get serialdevice
+$ kubectl get serialdevice
 NAME            READY   AVAILABLE   NODE
-ender3          True    False
-sonoff-zigbee   True    False
+ender3          True    True        worker-1
+sonoff-zigbee   True    True        worker-2
 ```
 
-You're all set with basic configuration of KubeSerial. Please read through rest of docs to configure it to your needs.
+A device shows `AVAILABLE=True` and a `NODE` once the monitor detects it plugged in. From here you can attach workloads to it: either through a predefined [Manager](configuration/managers/internal.md), or by annotating any pod for the [device-injection webhook](configuration/managers/external.md).
+
+You're all set with the basic configuration of KubeSerial. Read through the rest of the docs to configure it to your needs.


### PR DESCRIPTION
Finishes the mdBook docs — removes both `THIS IS STILL WORK IN PROGRESS` banners and the `development.md` TODO, and fills every placeholder page against the actual code.

- **intro.md**: real intro + architecture mermaid diagram + the two consumption modes (predefined Manager vs injection webhook).
- **development.md**: real build/test/codegen/e2e/local-cluster commands from the Makefile (replaced the TODO minikube stub).
- **components/** (controllers, monitor, gateway, manager) and **configuration/** pages filled with accurate, code-verified content.
- **configuration/managers/external.md**: documents the device-injection webhook end to end — the `app.kubeserial.com/inject-device` annotation, the Free-condition gate, the socat bridge to `<device>-gateway:3333`, OCI-entrypoint fallback, and current limitations (**addresses #72**).

Only `docs/src/**` touched. Markdown syntax-checked (couldn't build mdBook locally). Docs-authored notes: manager ingress documented as "not wired up" (code path is commented out), webhook first-container-only limitation taken from in-code TODOs.