### PR TITLE
feat(chart): log level, udev cleanup, device-monitor flags, dashboard

### DIFF
--- a/charts/kubeserial/dashboards/kubeserial.json
+++ b/charts/kubeserial/dashboards/kubeserial.json
@@ -1,0 +1,95 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "schemaVersion": 39,
+  "title": "KubeSerial",
+  "tags": ["kubeserial"],
+  "time": { "from": "now-6h", "to": "now" },
+  "timezone": "",
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Devices",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 0 },
+      "targets": [
+        { "expr": "devices", "legendFormat": "total", "refId": "A" }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Available devices",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 0 },
+      "targets": [
+        { "expr": "devices_available", "legendFormat": "available", "refId": "A" }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Ready devices",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 0 },
+      "targets": [
+        { "expr": "devices_ready", "legendFormat": "ready", "refId": "A" }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Devices monitored",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 0 },
+      "targets": [
+        { "expr": "devices_monitored", "legendFormat": "monitored", "refId": "A" }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Device counts over time",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "targets": [
+        { "expr": "devices", "legendFormat": "total", "refId": "A" },
+        { "expr": "devices_available", "legendFormat": "available", "refId": "B" },
+        { "expr": "devices_ready", "legendFormat": "ready", "refId": "C" },
+        { "expr": "devices_monitored", "legendFormat": "monitored", "refId": "D" }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Webhook pods handled",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 6 },
+      "targets": [
+        { "expr": "pods_handled", "legendFormat": "pods handled", "refId": "A" }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Injected commands rate",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 6 },
+      "targets": [
+        { "expr": "rate(injected_commands_total[5m])", "legendFormat": "injected commands/s", "refId": "A" }
+      ]
+    }
+  ]
+}

--- a/charts/kubeserial/specs/gateway-deployment.yaml
+++ b/charts/kubeserial/specs/gateway-deployment.yaml
@@ -43,8 +43,6 @@ spec:
         - mountPath: /etc/ser2net.conf
           name: config
           subPath: ser2net.conf
-      nodeSelector:
-        kubernetes.io/hostname: TODO
       volumes:
       - hostPath:
           path: /dev

--- a/charts/kubeserial/specs/monitor-daemonset.yaml
+++ b/charts/kubeserial/specs/monitor-daemonset.yaml
@@ -19,6 +19,18 @@ spec:
         resources: {{ .Values.monitor.resources | toYaml | nindent 14 }}
         securityContext:
           privileged: true
+        lifecycle:
+          preStop:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  rules=/etc/udev/rules.d/98-devices.rules
+                  [ -f "$rules" ] && sed -n 's/.*SYMLINK+="\([^"]*\)".*/\1/p' "$rules" | while read -r name; do
+                    rm -f "/dev/$name"
+                  done
+                  udevadm control --reload-rules 2>/dev/null || true
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -29,7 +41,7 @@ spec:
             subPath: 98-devices.rules
       - args:
           - -c
-          - ./go/bin/device-monitor
+          - ./go/bin/device-monitor --namespace=$(OPERATOR_NAMESPACE) --node-name=$(NODE_NAME)
         command:
           - /bin/sh
         env:

--- a/charts/kubeserial/templates/deployment.yaml
+++ b/charts/kubeserial/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
           args:
             - -leader-elect=true
             - -device-monitor-version={{ .Values.image.tag }}
+            - -zap-log-level={{ .Values.logLevel }}
           env:
             - name: WATCH_NAMESPACE
               value: {{ .Release.Namespace }}

--- a/charts/kubeserial/templates/device_injector_webhook_deployment.yaml
+++ b/charts/kubeserial/templates/device_injector_webhook_deployment.yaml
@@ -22,6 +22,7 @@ spec:
           args:
             - -certDir=/etc/webhook/certs
             - -port=8443
+            - -zap-log-level={{ .Values.logLevel }}
           volumeMounts:
             - name: webhook-certs
               mountPath: /etc/webhook/certs

--- a/charts/kubeserial/templates/grafana_dashboard.yaml
+++ b/charts/kubeserial/templates/grafana_dashboard.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.dashboard.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kubeserial.fullname" . }}-dashboard
+  labels:
+    grafana_dashboard: "1"
+    {{- include "kubeserial.labels" . | nindent 4 }}
+data:
+  kubeserial.json: |-
+    {{- .Files.Get "dashboards/kubeserial.json" | nindent 4 }}
+{{- end }}

--- a/charts/kubeserial/values.yaml
+++ b/charts/kubeserial/values.yaml
@@ -1,5 +1,7 @@
 replicaCount: 1
 
+logLevel: info
+
 kubeserial:
   serialDevices: []
 
@@ -29,6 +31,9 @@ image:
 monitoring:
   prometheusMonitors:
     enabled: false
+
+dashboard:
+  enabled: false
 
 ingress:
   enabled: false

--- a/cmd/device-monitor/main.go
+++ b/cmd/device-monitor/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"os"
 
 	"k8s.io/client-go/kubernetes"
@@ -14,18 +15,22 @@ import (
 )
 
 func main() {
+	var (
+		namespace string
+		nodeName  string
+	)
+	flag.StringVar(&namespace, "namespace", os.Getenv("OPERATOR_NAMESPACE"), "Namespace the device monitor watches")
+	flag.StringVar(&nodeName, "node-name", os.Getenv("NODE_NAME"), "Name of the node this monitor runs on")
 	opts := zap.Options{
 		Development: true,
 	}
+	opts.BindFlags(flag.CommandLine)
+	flag.Parse()
+
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	log := ctrl.Log.WithName("monitor")
 
 	log.Info("Start setup")
-
-	// _, err := metrics.NewListener(":8080")
-	// if err != nil {
-	// 	log.Info("Failed setting up metrics listener")
-	// }
 
 	config, err := rest.InClusterConfig()
 	if err != nil {
@@ -50,8 +55,8 @@ func main() {
 	deviceMonitor := monitor.NewMonitor(
 		clientset,
 		clientsetKubeserial,
-		os.Getenv("OPERATOR_NAMESPACE"),
-		os.Getenv("NODE_NAME"),
+		namespace,
+		nodeName,
 		utils.NewOSFS(),
 	)
 	log.Info("Starting monitor update loop")


### PR DESCRIPTION
Finishes several chart/config loose ends (open issues #59/#69/#47/#80).

- **#59 log level**: `logLevel: info` value threaded as `-zap-log-level` into the manager and webhook deployments.
- **#47 unify config**: `cmd/device-monitor` converted from `os.Getenv` to flags (`--namespace`/`--node-name`, env as fallback via downward API), matching the other binaries; DaemonSet updated to pass them.
- **#69 udev cleanup**: `preStop` hook on the udev-monitor container removes the managed `/dev/<name>` symlinks (parsed from the rules file) and reloads udev on uninstall.
- **gateway placeholder**: removed the misleading `nodeSelector: {kubernetes.io/hostname: TODO}` (the controller sets it at runtime from `device.Status.NodeName`).
- **#80 dashboard (chart side)**: Grafana dashboard ConfigMap (`grafana_dashboard: "1"`) gated behind `dashboard.enabled` (default false).

Verified: `helm lint` both charts, `helm template` renders, `go build`/`go test` green.

Note: the dashboard references the **actual** registered metric names (`devices`, `devices_available`, `devices_ready`, `devices_monitored`, `pods_handled`, `injected_commands_total`), not the prefixed names in the issue. `injected_commands_total` won't have data until the pkg-side PR registers that counter (in the code-quality workstream).