### PR TITLE
refactor(pkg): finish code-quality debt + metrics instrumentation

### DIFF
--- a/pkg/apis/v1alpha1/managerschedulerequest.go
+++ b/pkg/apis/v1alpha1/managerschedulerequest.go
@@ -33,7 +33,7 @@ type ManagerScheduleRequestSpec struct {
 // ManagerScheduleRequestStatus defines the observed state of ManagerScheduleRequest.
 type ManagerScheduleRequestStatus struct {
 	// +kubebuilder:default:=false
-	Fulfilled bool `json:"fulfilled"` // TODO: this is still empty when created
+	Fulfilled bool `json:"fulfilled"`
 }
 
 // +genclient

--- a/pkg/apis/v1alpha1/serialdevice.go
+++ b/pkg/apis/v1alpha1/serialdevice.go
@@ -124,18 +124,20 @@ func (d *SerialDevice) NeedsManager() bool {
 }
 
 func (d *SerialDevice) IsAvailable() bool {
-	availableCondition := d.GetCondition(SerialDeviceAvailable)
-	return availableCondition.Status == metav1.ConditionTrue
+	return d.conditionIsTrue(SerialDeviceAvailable)
 }
 
 func (d *SerialDevice) IsReady() bool {
-	readyCondition := d.GetCondition(SerialDeviceReady)
-	return readyCondition.Status == metav1.ConditionTrue
+	return d.conditionIsTrue(SerialDeviceReady)
 }
 
 func (d *SerialDevice) IsFree() bool {
-	freeCondition := d.GetCondition(SerialDeviceFree)
-	return freeCondition.Status == metav1.ConditionTrue
+	return d.conditionIsTrue(SerialDeviceFree)
+}
+
+func (d *SerialDevice) conditionIsTrue(conditionType SerialDeviceConditionType) bool {
+	condition := d.GetCondition(conditionType)
+	return condition != nil && condition.Status == metav1.ConditionTrue
 }
 
 func (d *SerialDevice) GetCondition(conditionType SerialDeviceConditionType) *SerialDeviceCondition {

--- a/pkg/controllers/device_controller.go
+++ b/pkg/controllers/device_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -36,6 +37,7 @@ import (
 	"github.com/janekbaraniewski/kubeserial/pkg/gateway"
 	api "github.com/janekbaraniewski/kubeserial/pkg/kubeapi"
 	"github.com/janekbaraniewski/kubeserial/pkg/utils"
+	"github.com/janekbaraniewski/kubeserial/pkg/utils/apis"
 )
 
 var devLog = logf.Log.WithName("DeviceController")
@@ -58,6 +60,8 @@ type SerialDeviceReconciler struct {
 func (r *SerialDeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := devLog.WithName("Reconcile")
 	logger.Info("Starting device reconcile", "req", req)
+
+	defer r.updateMetrics(ctx, logger)
 
 	device := &kubeserialv1alpha1.SerialDevice{}
 	err := r.Get(ctx, req.NamespacedName, device)
@@ -127,7 +131,10 @@ func (r *SerialDeviceReconciler) HandleDeviceUnavailable(
 }
 
 func (r *SerialDeviceReconciler) RequestGateway(ctx context.Context, device *kubeserialv1alpha1.SerialDevice) error {
-	gatewayObjects := gateway.NewBuilder(device, r.FS).Build()
+	gatewayObjects, err := gateway.NewBuilder(device, r.FS).Build()
+	if err != nil {
+		return fmt.Errorf("building gateway objects: %w", err)
+	}
 
 	for _, o := range gatewayObjects {
 		if err := r.APIClient.EnsureObject(ctx, device, o); err != nil {
@@ -139,7 +146,7 @@ func (r *SerialDeviceReconciler) RequestGateway(ctx context.Context, device *kub
 }
 
 func (r *SerialDeviceReconciler) EnsureNoGatewayRunning(ctx context.Context, device *kubeserialv1alpha1.SerialDevice) error {
-	name := device.Name + "-gateway" // TODO: move name generation to some utils so it's in one place
+	name := apis.GatewayName(device.Name)
 
 	if err := r.APIClient.DeleteObject(
 		ctx,
@@ -266,7 +273,7 @@ func (r *SerialDeviceReconciler) RequestManager(ctx context.Context, device *kub
 	}
 	request := &kubeserialv1alpha1.ManagerScheduleRequest{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      device.Name + "-" + device.Spec.Manager,
+			Name:      apis.ScheduleRequestName(device.Name, device.Spec.Manager),
 			Namespace: device.Namespace,
 		},
 		Spec: kubeserialv1alpha1.ManagerScheduleRequestSpec{
@@ -292,7 +299,7 @@ func (r *SerialDeviceReconciler) EnsureNoManagerRequested(ctx context.Context, d
 	}
 	request := &kubeserialv1alpha1.ManagerScheduleRequest{}
 	if err := r.Get(ctx, types.NamespacedName{
-		Name:      device.Name + "-" + device.Spec.Manager,
+		Name:      apis.ScheduleRequestName(device.Name, device.Spec.Manager),
 		Namespace: device.Namespace,
 	}, request); err != nil {
 		if errors.IsNotFound(err) {
@@ -301,6 +308,29 @@ func (r *SerialDeviceReconciler) EnsureNoManagerRequested(ctx context.Context, d
 		return err
 	}
 	return r.Delete(ctx, request)
+}
+
+// updateMetrics refreshes the device gauges from the full set of SerialDevices.
+func (r *SerialDeviceReconciler) updateMetrics(ctx context.Context, logger logr.Logger) {
+	list := &kubeserialv1alpha1.SerialDeviceList{}
+	if err := r.List(ctx, list); err != nil {
+		logger.Error(err, "Failed listing devices for metrics")
+		return
+	}
+
+	var available, ready float64
+	for i := range list.Items {
+		if list.Items[i].IsAvailable() {
+			available++
+		}
+		if list.Items[i].IsReady() {
+			ready++
+		}
+	}
+
+	Devices.Set(float64(len(list.Items)))
+	AvailableDevices.Set(available)
+	ReadyDevices.Set(ready)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/controllers/device_controller_test.go
+++ b/pkg/controllers/device_controller_test.go
@@ -16,20 +16,23 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	runtimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestDeviceReconciler_Reconcile(t *testing.T) { //nolint:paralleltest
-	// t.Parallel()
-	deviceName := types.NamespacedName{
-		Name:      "test-device",
-		Namespace: "test-ns",
-	}
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.Install(scheme))
+	return scheme
+}
 
-	device := &v1alpha1.SerialDevice{
+func newTestDevice() *v1alpha1.SerialDevice {
+	return &v1alpha1.SerialDevice{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      deviceName.Name,
-			Namespace: deviceName.Namespace,
+			Name:      "test-device",
+			Namespace: "test-ns",
 		},
 		Spec: v1alpha1.SerialDeviceSpec{
 			Manager:   "test-manager",
@@ -38,8 +41,10 @@ func TestDeviceReconciler_Reconcile(t *testing.T) { //nolint:paralleltest
 			Name:      "test-device",
 		},
 	}
+}
 
-	manager := &v1alpha1.Manager{
+func newTestManager() *v1alpha1.Manager {
+	return &v1alpha1.Manager{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "test-manager",
 			Namespace: "test-ns",
@@ -54,153 +59,118 @@ func TestDeviceReconciler_Reconcile(t *testing.T) { //nolint:paralleltest
 			RunCmd:     "./test-manager",
 		},
 	}
+}
 
-	scheme := runtime.NewScheme()
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(v1alpha1.Install(scheme))
-	fakeClient := runtimefake.NewClientBuilder().WithScheme(scheme).Build()
-	fs := utils.NewInMemoryFS()
-	AddGatewaySpecFilesToFilesystem(t, fs)
-	{
-		t.Run("device-new-manager-not-available", func(t *testing.T) {
-			// t.Parallel()
-			t.Skip()
-			if err := fakeClient.Create(context.TODO(), device); err != nil {
-				t.Logf("ERROR - %v", err)
-				t.Fail()
-			}
-
-			deviceReconciler := SerialDeviceReconciler{
-				Client:    fakeClient,
-				Scheme:    scheme,
-				APIClient: kubeapi.NewFakeAPIClient(),
-				FS:        fs,
-			}
-
-			result, err := deviceReconciler.Reconcile(context.TODO(), controllerruntime.Request{NamespacedName: deviceName})
-
-			require.NoError(t, err)
-			assert.Equal(t, controllerruntime.Result{}, result)
-
-			foundDevice := &v1alpha1.SerialDevice{}
-			err = fakeClient.Get(context.TODO(), deviceName, foundDevice)
-
-			require.NoError(t, err)
-			// assert.Equal(t, 3, len(foundDevice.Status.Conditions))
-
-			availableCondition := foundDevice.GetCondition(v1alpha1.SerialDeviceAvailable)
-			assert.Equal(t, v1.ConditionFalse, availableCondition.Status)
-			assert.Equal(t, "NotValidated", availableCondition.Reason)
-
-			readyCondition := foundDevice.GetCondition(v1alpha1.SerialDeviceReady)
-			assert.Equal(t, v1.ConditionFalse, readyCondition.Status)
-			assert.Equal(t, "ManagerNotAvailable", readyCondition.Reason)
-		})
+func TestDeviceReconciler_Reconcile(t *testing.T) {
+	t.Parallel()
+	deviceName := types.NamespacedName{
+		Name:      "test-device",
+		Namespace: "test-ns",
 	}
-	{
-		t.Run("device-new-manager-available", func(t *testing.T) {
-			// t.Parallel()
-			t.Skip()
 
-			if err := fakeClient.Create(context.TODO(), device); err != nil {
-				t.Logf("Error returned -> %v", err)
-				t.Fail()
-			}
-
-			if err := fakeClient.Create(context.TODO(), manager); err != nil {
-				t.Logf("Error returned -> %v", err)
-				t.Fail()
-			}
-
-			deviceReconciler := SerialDeviceReconciler{
-				Client:    fakeClient,
-				Scheme:    scheme,
-				APIClient: kubeapi.NewFakeAPIClient(),
-				FS:        fs,
-			}
-
-			result, err := deviceReconciler.Reconcile(context.TODO(), controllerruntime.Request{NamespacedName: deviceName})
-
-			require.NoError(t, err)
-			assert.Equal(t, controllerruntime.Result{}, result)
-
-			foundDevice := &v1alpha1.SerialDevice{}
-			//nolint:errcheck
-			fakeClient.Get(context.TODO(), deviceName, foundDevice)
-
-			availableCondition := foundDevice.GetCondition(v1alpha1.SerialDeviceAvailable)
-			assert.Equal(t, v1.ConditionFalse, availableCondition.Status)
-			assert.Equal(t, "NotValidated", availableCondition.Reason)
-
-			readyCondition := foundDevice.GetCondition(v1alpha1.SerialDeviceReady)
-			assert.Equal(t, v1.ConditionTrue, readyCondition.Status)
-			assert.Equal(t, "AllChecksPassed", readyCondition.Reason)
-		})
+	newReconciler := func(scheme *runtime.Scheme, objs ...client.Object) (SerialDeviceReconciler, client.Client) {
+		fs := utils.NewInMemoryFS()
+		AddGatewaySpecFilesToFilesystem(t, fs)
+		fakeClient := runtimefake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&v1alpha1.SerialDevice{}).
+			WithObjects(objs...).
+			Build()
+		return SerialDeviceReconciler{
+			Client:    fakeClient,
+			Scheme:    scheme,
+			APIClient: kubeapi.NewFakeAPIClient(),
+			FS:        fs,
+		}, fakeClient
 	}
-	{
-		t.Run("device-ready", func(t *testing.T) {
-			// t.Parallel()
-			t.Skip()
-			device.Status.Conditions = append(device.Status.Conditions, v1alpha1.SerialDeviceCondition{
-				Type:   v1alpha1.SerialDeviceAvailable,
-				Status: v1.ConditionTrue,
-			})
 
-			err := fakeClient.Create(context.TODO(), device)
-			t.Logf("Error returned -> %v", err)
-			if err != nil {
-				t.Fail()
-			}
+	t.Run("device-new-manager-not-available", func(t *testing.T) {
+		t.Parallel()
+		scheme := newTestScheme(t)
+		reconciler, fakeClient := newReconciler(scheme, newTestDevice())
 
-			//nolint:errcheck
-			fakeClient.Create(context.TODO(), manager)
+		result, err := reconciler.Reconcile(context.TODO(), controllerruntime.Request{NamespacedName: deviceName})
+		require.NoError(t, err)
+		assert.Equal(t, controllerruntime.Result{}, result)
 
-			deviceReconciler := SerialDeviceReconciler{
-				Client:    fakeClient,
-				Scheme:    scheme,
-				APIClient: kubeapi.NewFakeAPIClient(),
-				FS:        fs,
-			}
+		foundDevice := &v1alpha1.SerialDevice{}
+		require.NoError(t, fakeClient.Get(context.TODO(), deviceName, foundDevice))
+		assert.Len(t, foundDevice.Status.Conditions, 3)
 
-			result, err := deviceReconciler.Reconcile(context.TODO(), controllerruntime.Request{NamespacedName: deviceName})
+		availableCondition := foundDevice.GetCondition(v1alpha1.SerialDeviceAvailable)
+		require.NotNil(t, availableCondition)
+		assert.Equal(t, v1.ConditionFalse, availableCondition.Status)
+		assert.Equal(t, "NotValidated", availableCondition.Reason)
 
-			require.NoError(t, err)
-			assert.Equal(t, controllerruntime.Result{}, result)
+		readyCondition := foundDevice.GetCondition(v1alpha1.SerialDeviceReady)
+		require.NotNil(t, readyCondition)
+		assert.Equal(t, v1.ConditionFalse, readyCondition.Status)
+		assert.Equal(t, "ManagerNotAvailable", readyCondition.Reason)
+	})
 
-			foundDevice := &v1alpha1.SerialDevice{}
-			//nolint:errcheck
-			fakeClient.Get(context.TODO(), deviceName, foundDevice)
+	t.Run("device-new-manager-available", func(t *testing.T) {
+		t.Parallel()
+		scheme := newTestScheme(t)
+		reconciler, fakeClient := newReconciler(scheme, newTestDevice(), newTestManager())
 
-			readyCondition := foundDevice.GetCondition(v1alpha1.SerialDeviceReady)
-			assert.Equal(t, v1.ConditionTrue, readyCondition.Status)
-			assert.Equal(t, "AllChecksPassed", readyCondition.Reason)
+		result, err := reconciler.Reconcile(context.TODO(), controllerruntime.Request{NamespacedName: deviceName})
+		require.NoError(t, err)
+		assert.Equal(t, controllerruntime.Result{}, result)
 
-			foundRequest := v1alpha1.ManagerScheduleRequest{}
-			//nolint:errcheck
-			fakeClient.Get(context.TODO(), types.NamespacedName{
-				Name:      device.Name + "-" + device.Spec.Manager,
-				Namespace: device.Name,
-			}, &foundRequest)
+		foundDevice := &v1alpha1.SerialDevice{}
+		require.NoError(t, fakeClient.Get(context.TODO(), deviceName, foundDevice))
 
-			assert.False(t, foundRequest.Status.Fulfilled)
+		availableCondition := foundDevice.GetCondition(v1alpha1.SerialDeviceAvailable)
+		require.NotNil(t, availableCondition)
+		assert.Equal(t, v1.ConditionFalse, availableCondition.Status)
+		assert.Equal(t, "NotValidated", availableCondition.Reason)
+
+		readyCondition := foundDevice.GetCondition(v1alpha1.SerialDeviceReady)
+		require.NotNil(t, readyCondition)
+		assert.Equal(t, v1.ConditionTrue, readyCondition.Status)
+		assert.Equal(t, "AllChecksPassed", readyCondition.Reason)
+	})
+
+	t.Run("device-ready", func(t *testing.T) {
+		t.Parallel()
+		scheme := newTestScheme(t)
+		device := newTestDevice()
+		device.Status.Conditions = append(device.Status.Conditions, v1alpha1.SerialDeviceCondition{
+			Type:   v1alpha1.SerialDeviceAvailable,
+			Status: v1.ConditionTrue,
 		})
-	}
-	{
-		t.Run("device-not-found", func(t *testing.T) {
-			// t.Parallel()
-			// t.Skip()
-			deviceReconciler := SerialDeviceReconciler{
-				Client:    fakeClient,
-				Scheme:    scheme,
-				APIClient: kubeapi.NewFakeAPIClient(),
-				FS:        fs,
-			}
+		reconciler, fakeClient := newReconciler(scheme, device, newTestManager())
 
-			result, err := deviceReconciler.Reconcile(context.TODO(), controllerruntime.Request{NamespacedName: deviceName})
-			require.NoError(t, err)
-			assert.Equal(t, controllerruntime.Result{}, result)
-		})
-	}
+		result, err := reconciler.Reconcile(context.TODO(), controllerruntime.Request{NamespacedName: deviceName})
+		require.NoError(t, err)
+		assert.Equal(t, controllerruntime.Result{}, result)
+
+		foundDevice := &v1alpha1.SerialDevice{}
+		require.NoError(t, fakeClient.Get(context.TODO(), deviceName, foundDevice))
+
+		readyCondition := foundDevice.GetCondition(v1alpha1.SerialDeviceReady)
+		require.NotNil(t, readyCondition)
+		assert.Equal(t, v1.ConditionTrue, readyCondition.Status)
+		assert.Equal(t, "AllChecksPassed", readyCondition.Reason)
+
+		// Device controller only creates the request; the MSR controller fulfills it.
+		foundRequest := &v1alpha1.ManagerScheduleRequest{}
+		require.NoError(t, fakeClient.Get(context.TODO(), types.NamespacedName{
+			Name:      device.Name + "-" + device.Spec.Manager,
+			Namespace: device.Namespace,
+		}, foundRequest))
+		assert.False(t, foundRequest.Status.Fulfilled)
+	})
+
+	t.Run("device-not-found", func(t *testing.T) {
+		t.Parallel()
+		scheme := newTestScheme(t)
+		reconciler, _ := newReconciler(scheme)
+
+		result, err := reconciler.Reconcile(context.TODO(), controllerruntime.Request{NamespacedName: deviceName})
+		require.NoError(t, err)
+		assert.Equal(t, controllerruntime.Result{}, result)
+	})
 }
 
 func AddGatewaySpecFilesToFilesystem(t *testing.T, fs *utils.InMemoryFS) {

--- a/pkg/controllers/managerschedulerequest_controller.go
+++ b/pkg/controllers/managerschedulerequest_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -74,14 +75,43 @@ func (r *ManagerScheduleRequestReconciler) Reconcile(ctx context.Context, req ct
 		Namespace: req.Namespace,
 	}, manager)
 	if err != nil {
-		// TODO: handle missing manager spec
-		return ctrl.Result{}, err
+		if errors.IsNotFound(err) {
+			logger.Info("Referenced manager not found, marking request unfulfilled and requeueing",
+				"manager", instance.Spec.Manager)
+			if statusErr := r.setFulfilled(ctx, instance, false); statusErr != nil {
+				return ctrl.Result{}, statusErr
+			}
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("getting manager %q: %w", instance.Spec.Manager, err)
 	}
 	logger = logger.WithValues("manager", manager)
 	logger.Info("Got manager, starting ReconcileManager")
-	err = r.ReconcileManager(ctx, instance, manager, req)
+	if err := r.ReconcileManager(ctx, instance, manager, req); err != nil {
+		return ctrl.Result{}, err
+	}
 
-	return ctrl.Result{}, err
+	if err := r.setFulfilled(ctx, instance, true); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// setFulfilled updates the request's Fulfilled status if it changed.
+func (r *ManagerScheduleRequestReconciler) setFulfilled(
+	ctx context.Context,
+	instance *kubeserialv1alpha1.ManagerScheduleRequest,
+	fulfilled bool,
+) error {
+	if instance.Status.Fulfilled == fulfilled {
+		return nil
+	}
+	instance.Status.Fulfilled = fulfilled
+	if err := r.Status().Update(ctx, instance); err != nil {
+		return fmt.Errorf("updating ManagerScheduleRequest status: %w", err)
+	}
+	return nil
 }
 
 // ReconcileManager.

--- a/pkg/controllers/managerschedulerequest_controller_test.go
+++ b/pkg/controllers/managerschedulerequest_controller_test.go
@@ -24,7 +24,8 @@ func TestManagerScheduleRequestReconcile(t *testing.T) {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(v1alpha1.Install(scheme))
-	fakeClient := runtimefake.NewClientBuilder().WithScheme(scheme).Build()
+	fakeClient := runtimefake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&v1alpha1.ManagerScheduleRequest{}).Build()
 
 	reconciler := ManagerScheduleRequestReconciler{
 		Client: fakeClient,
@@ -77,7 +78,8 @@ func TestManagerScheduleRequestReconcile_DeviceFoundNoManager(t *testing.T) {
 	fs := utils.NewInMemoryFS()
 	AddSpecFilesToFilesystem(t, fs)
 
-	fakeClient := runtimefake.NewClientBuilder().WithScheme(scheme).Build()
+	fakeClient := runtimefake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&v1alpha1.ManagerScheduleRequest{}).Build()
 	//nolint:errcheck
 	fakeClient.Create(context.TODO(), mgr)
 	//nolint:errcheck
@@ -129,7 +131,8 @@ func TestManagerScheduleRequestReconcile_DeviceManagerFound(t *testing.T) {
 		},
 	}
 
-	fakeClient := runtimefake.NewClientBuilder().WithScheme(scheme).Build()
+	fakeClient := runtimefake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&v1alpha1.ManagerScheduleRequest{}).Build()
 	//nolint:errcheck
 	fakeClient.Create(context.TODO(), msr)
 	//nolint:errcheck

--- a/pkg/gateway/resources.go
+++ b/pkg/gateway/resources.go
@@ -6,11 +6,16 @@ import (
 	kubeserial "github.com/janekbaraniewski/kubeserial/pkg"
 	appv1alpha1 "github.com/janekbaraniewski/kubeserial/pkg/apis/v1alpha1"
 	"github.com/janekbaraniewski/kubeserial/pkg/utils"
+	"github.com/janekbaraniewski/kubeserial/pkg/utils/apis"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// configVolumeName is the name of the config volume defined in the gateway
+// deployment spec; the config map is wired into it by name at build time.
+const configVolumeName = "config"
 
 type Builder struct {
 	Device *appv1alpha1.SerialDevice
@@ -24,30 +29,28 @@ func NewBuilder(device *appv1alpha1.SerialDevice, fs utils.FileSystem) *Builder 
 	}
 }
 
-func (g *Builder) Build() []client.Object {
+func (g *Builder) Build() ([]client.Object, error) {
 	cm, err := CreateConfigMap(g.Device, g.FS)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("building gateway config map: %w", err)
 	}
 
 	dpl, err := CreateDeployment(g.Device, g.FS)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("building gateway deployment: %w", err)
 	}
 
 	svc, err := CreateService(g.Device, g.FS)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("building gateway service: %w", err)
 	}
 
-	return []client.Object{
-		cm, dpl, svc,
-	}
+	return []client.Object{cm, dpl, svc}, nil
 }
 
 func CreateConfigMap(device metav1.Object, fs utils.FileSystem) (*corev1.ConfigMap, error) {
 	cm := &corev1.ConfigMap{}
-	name := fmt.Sprintf("%v-gateway", device.GetName())
+	name := apis.GatewayName(device.GetName())
 
 	conf := fmt.Sprintf(
 		"3333:raw:600:/dev/%v:115200 8DATABITS NONE 1STOPBIT -XONXOFF LOCAL -RTSCTS HANGUP_WHEN_DONE\n",
@@ -71,7 +74,7 @@ func CreateDeployment(device *appv1alpha1.SerialDevice, fs utils.FileSystem) (*a
 	if err := utils.LoadResourceFromYaml(fs, kubeserial.GatewayDeploySpecPath, deployment); err != nil {
 		return deployment, err
 	}
-	name := fmt.Sprintf("%v-gateway", device.GetName())
+	name := apis.GatewayName(device.GetName())
 
 	deployment.Name = name
 	deployment.Labels[string(kubeserial.AppNameLabel)] = name
@@ -85,7 +88,7 @@ func CreateDeployment(device *appv1alpha1.SerialDevice, fs utils.FileSystem) (*a
 	volumes := []corev1.Volume{}
 
 	for _, volume := range deployment.Spec.Template.Spec.Volumes {
-		if volume.Name == "config" { // TODO: fix this, shouldn't be hardcoded string
+		if volume.Name == configVolumeName {
 			volume.ConfigMap.Name = name
 		}
 		volumes = append(volumes, volume)
@@ -100,7 +103,7 @@ func CreateService(device *appv1alpha1.SerialDevice, fs utils.FileSystem) (*core
 	if err := utils.LoadResourceFromYaml(fs, kubeserial.GatewaySvcSpecPath, svc); err != nil {
 		return svc, err
 	}
-	name := fmt.Sprintf("%v-gateway", device.GetName())
+	name := apis.GatewayName(device.GetName())
 	svc.Name = name
 	svc.Labels[string(kubeserial.AppNameLabel)] = name
 	svc.Spec.Selector[string(kubeserial.AppNameLabel)] = name

--- a/pkg/gateway/resources_test.go
+++ b/pkg/gateway/resources_test.go
@@ -23,10 +23,26 @@ func TestBuilder_Build(t *testing.T) {
 		},
 	}
 
-	objects := NewBuilder(device, fs).Build()
+	objects, err := NewBuilder(device, fs).Build()
 
-	assert.NotNil(t, objects)
+	require.NoError(t, err)
 	assert.Len(t, objects, 3)
+}
+
+func TestBuilder_BuildMissingSpecs(t *testing.T) {
+	t.Parallel()
+	fs := utils.NewInMemoryFS()
+
+	device := &v1alpha1.SerialDevice{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-device",
+		},
+	}
+
+	objects, err := NewBuilder(device, fs).Build()
+
+	require.Error(t, err)
+	assert.Nil(t, objects)
 }
 
 func TestCreateConfigMap(t *testing.T) {

--- a/pkg/managers/manager.go
+++ b/pkg/managers/manager.go
@@ -10,10 +10,9 @@ import (
 	appv1alpha1 "github.com/janekbaraniewski/kubeserial/pkg/apis/v1alpha1"
 	api "github.com/janekbaraniewski/kubeserial/pkg/kubeapi"
 	"github.com/janekbaraniewski/kubeserial/pkg/utils"
+	"github.com/janekbaraniewski/kubeserial/pkg/utils/apis"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -71,13 +70,6 @@ func Schedule(
 		return err
 	}
 
-	// TODO: bring back ingress support
-	// if cr.Spec.Ingress.Enabled {
-	// 	ingress := manager.CreateIngress(cr, device, cr.Spec.Ingress.Domain)
-	// 	if err := api.EnsureIngress(ctx, cr, ingress); err != nil {
-	// 		return err
-	// 	}
-	// }
 	return nil
 }
 
@@ -115,7 +107,7 @@ func (m *Manager) CreateDeployment(cr types.NamespacedName, deviceName string, i
 		"-c",
 		fmt.Sprintf(
 			"socat -d -d pty,raw,echo=0,b115200,link=/dev/device,perm=0660,group=tty tcp:%v:3333 & %v",
-			strings.ToLower(deviceName+"-gateway"), m.RunCmnd,
+			strings.ToLower(apis.GatewayName(deviceName)), m.RunCmnd,
 		),
 	}
 
@@ -168,65 +160,3 @@ func (m *Manager) CreateService(cr types.NamespacedName, deviceName string) (*co
 
 	return svc, nil
 }
-
-func (m *Manager) Delete(ctx context.Context, cr *appv1alpha1.KubeSerial, device *appv1alpha1.ManagedDevice, api api.API) error {
-	name := m.GetName(cr.Name, device.Name)
-
-	if err := api.DeleteObject(ctx, &appsv1.Deployment{ObjectMeta: v1.ObjectMeta{Name: name, Namespace: cr.Namespace}}); err != nil {
-		return err
-	}
-	if err := api.DeleteObject(ctx, &corev1.ConfigMap{ObjectMeta: v1.ObjectMeta{Name: name, Namespace: cr.Namespace}}); err != nil {
-		return err
-	}
-	if err := api.DeleteObject(ctx, &corev1.Service{ObjectMeta: v1.ObjectMeta{Name: name, Namespace: cr.Namespace}}); err != nil {
-		return err
-	}
-	if err := api.DeleteObject(
-		ctx, &networkingv1.Ingress{ObjectMeta: v1.ObjectMeta{Name: name, Namespace: cr.Namespace}}); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-//nolint
-// func (m *Manager) CreateIngress(cr *appv1alpha1.KubeSerial, device *appv1alpha1.ManagedDevice, domain string) *networkingv1.Ingress {
-// 	name := m.GetName(cr.Name, device.Name)
-// 	labels := map[string]string{
-// 		"app": name,
-// 	}
-// 	typePrefix := networkingv1.PathTypePrefix
-// 	return &networkingv1.Ingress{
-// 		ObjectMeta: metav1.ObjectMeta{
-// 			Name:        name,
-// 			Namespace:   cr.Namespace,
-// 			Labels:      labels,
-// 			Annotations: cr.Spec.Ingress.Annotations,
-// 		},
-// 		Spec: networkingv1.IngressSpec{
-// 			Rules: []networkingv1.IngressRule{
-// 				{
-// 					Host: strings.ToLower(device.Name + domain),
-// 					IngressRuleValue: networkingv1.IngressRuleValue{
-// 						HTTP: &networkingv1.HTTPIngressRuleValue{
-// 							Paths: []networkingv1.HTTPIngressPath{
-// 								{
-// 									Path:     "/",
-// 									PathType: &typePrefix,
-// 									Backend: networkingv1.IngressBackend{
-// 										Service: &networkingv1.IngressServiceBackend{
-// 											Name: m.GetName(cr.Name, device.Name),
-// 											Port: networkingv1.ServiceBackendPort{
-// 												Number: 80,
-// 											},
-// 										},
-// 									},
-// 								},
-// 							},
-// 						},
-// 					},
-// 				},
-// 			},
-// 		},
-// 	}
-// }

--- a/pkg/managers/manager_test.go
+++ b/pkg/managers/manager_test.go
@@ -30,15 +30,6 @@ func TestSchedule(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestDelete(t *testing.T) {
-	t.Parallel()
-	manager := Manager{}
-
-	err := manager.Delete(context.TODO(), &v1alpha1.KubeSerial{}, &v1alpha1.ManagedDevice{}, kubeapi.NewFakeAPIClient())
-
-	assert.NoError(t, err)
-}
-
 func AddSpecFilesToFilesystem(t *testing.T, fs *utils.InMemoryFS) {
 	t.Helper()
 	if err := fs.AddFileFromHostPath(string(kubeserial.ManagerCMSpecPath)); err != nil {

--- a/pkg/managers/util.go
+++ b/pkg/managers/util.go
@@ -1,7 +1,7 @@
 package managers
 
-import "strings"
+import "github.com/janekbaraniewski/kubeserial/pkg/utils/apis"
 
 func (m *Manager) GetName(crName string, deviceName string) string {
-	return strings.ToLower(crName + "-" + deviceName + "-manager")
+	return apis.ManagerName(crName, deviceName)
 }

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -64,6 +64,7 @@ func (m *Monitor) UpdateDeviceState(ctx context.Context) {
 		log.Error(err, "Failed listing SerialDevice CRs")
 		return
 	}
+	DevicesMonitored.Set(float64(len(devices.Items)))
 	readyDevices := make([]v1alpha1.SerialDevice, 0, len(devices.Items))
 	for _, device := range devices.Items {
 		readyCondition := device.GetCondition(v1alpha1.SerialDeviceReady)

--- a/pkg/utils/apis/names.go
+++ b/pkg/utils/apis/names.go
@@ -1,0 +1,28 @@
+// Package apis holds helpers for deriving the names of the Kubernetes objects
+// kubeserial creates, so the naming scheme lives in one place.
+package apis
+
+import "strings"
+
+const (
+	gatewaySuffix = "-gateway"
+	managerSuffix = "-manager"
+)
+
+// ScheduleRequestName returns the name of the ManagerScheduleRequest created
+// for the given device/manager pair.
+func ScheduleRequestName(deviceName, managerName string) string {
+	return deviceName + "-" + managerName
+}
+
+// GatewayName returns the name of the gateway objects (config map, deployment,
+// service) created for the given device.
+func GatewayName(deviceName string) string {
+	return deviceName + gatewaySuffix
+}
+
+// ManagerName returns the name of the manager objects scheduled for the given
+// schedule-request/device pair.
+func ManagerName(requestName, deviceName string) string {
+	return strings.ToLower(requestName + "-" + deviceName + managerSuffix)
+}

--- a/pkg/webhooks/metrics.go
+++ b/pkg/webhooks/metrics.go
@@ -20,5 +20,6 @@ var (
 func init() {
 	metrics.Registry.MustRegister(
 		PodsHandled,
+		InjectedCommands,
 	)
 }


### PR DESCRIPTION
Finishes the remaining pkg/** code-quality items (started by an agent, verified + completed by me — build, vet, tests, and golangci-lint v2 uncapped all clean).

- **gateway Build()**: returns `([]client.Object, error)` instead of a silent `nil`; caller (`RequestGateway`) propagates. Hardcoded `"config"` volume name → named const.
- **DRY naming**: extracted the object-name scheme into `pkg/utils/apis` (`GatewayName`/`ManagerName`/`ScheduleRequestName`) and used it everywhere names were concatenated by hand (removed the "move name generation to utils" TODO).
- **managerschedulerequest**: a missing referenced Manager now marks the request unfulfilled + requeues (was a bare error); `Status.Fulfilled` is set when satisfied (removed the "still empty when created" TODO).
- **serialdevice**: `IsAvailable/IsReady/IsFree` now go through a nil-safe helper (previously dereferenced a possibly-nil condition — latent panic).
- **dead code**: removed the commented-out ingress block and the unused `Manager.Delete` method (+ its test).
- **#80 metrics**: registered `InjectedCommands` (was defined but never `MustRegister`'d → never scraped); populate `Devices`/`AvailableDevices`/`ReadyDevices` from reconciler state (via a deferred `updateMetrics`) and `DevicesMonitored` from the monitor's count.
- **tests**: unskipped the three `t.Skip()` device-controller reconcile tests and made them pass; fixed the MSR controller tests to register the status subresource on the fake client.

Explicit non-goals (tracked follow-ups, not done here): metav1.Condition migration, finalizers, multi-container webhook support, DNS-1123 device-name validation.

**Flag for review:** I removed `Manager.Delete` as dead code (no non-test references); veto if you intended to wire it up for manager teardown.